### PR TITLE
Add initial project directory structure with .gitkeep files

### DIFF
--- a/backend/app/api/.gitkeep
+++ b/backend/app/api/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures that the api directory is tracked by Git
+# even when it contains no other files

--- a/backend/app/auth/.gitkeep
+++ b/backend/app/auth/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures that the auth directory is tracked by Git
+# even when it contains no other files

--- a/backend/app/pipelines/.gitkeep
+++ b/backend/app/pipelines/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures that the pipelines directory is tracked by Git
+# even when it contains no other files

--- a/backend/app/tasks/.gitkeep
+++ b/backend/app/tasks/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures that the tasks directory is tracked by Git
+# even when it contains no other files

--- a/frontend/src/components/.gitkeep
+++ b/frontend/src/components/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures that the components directory is tracked by Git
+# even when it contains no other files

--- a/frontend/src/pages/.gitkeep
+++ b/frontend/src/pages/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures that the pages directory is tracked by Git
+# even when it contains no other files

--- a/frontend/src/services/.gitkeep
+++ b/frontend/src/services/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures that the services directory is tracked by Git
+# even when it contains no other files

--- a/infra/.gitkeep
+++ b/infra/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures that the infra directory is tracked by Git
+# even when it contains no other files


### PR DESCRIPTION
## Description

This PR adds the initial directory structure for the Fluxio project by creating .gitkeep files in empty directories to ensure they are tracked by Git.

The following directories now have .gitkeep files:
- `infra/` - Infrastructure configuration and deployment files
- `backend/app/api/` - API endpoint implementations  
- `backend/app/auth/` - Authentication and authorization logic
- `backend/app/pipelines/` - Data pipeline processing logic
- `backend/app/tasks/` - Background task implementations
- `frontend/src/components/` - React/UI components
- `frontend/src/pages/` - Application pages/routes
- `frontend/src/services/` - API clients and external service integrations

Fixes #2

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's coding style and guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
- [x] I have checked that this PR does not introduce breaking changes

## Screenshots (if applicable)

N/A - This change only adds directory structure.

## Additional Context

This establishes the foundational project structure for Fluxio, ensuring that all planned directories are present in the repository even before actual implementation files are added. This will help with project organization and make it easier for contributors to understand where different types of code should be placed.